### PR TITLE
Fix listContents() when includes a directory

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -199,14 +199,17 @@ class SftpAdapter extends AbstractFtpAdapter
     protected function normalizeListingObject($path, array $object)
     {
         $permissions = $this->normalizePermissions($object['permissions']);
+        $type = ($object['type'] === 1) ? 'file' : 'dir' ;
+        $timestamp = $object['mtime'];
 
-        return [
-            'path'       => $path,
-            'size'       => $object['size'],
-            'timestamp'  => $object['mtime'],
-            'type'       => ($object['type'] === 1 ? 'file' : 'dir'),
-            'visibility' => $permissions & 0044 ? AdapterInterface::VISIBILITY_PUBLIC : AdapterInterface::VISIBILITY_PRIVATE,
-        ];
+        if ($type === 'dir') {
+            return compact('path', 'timestamp', 'type');
+        }
+
+        $visibility = $permissions & 0044 ? AdapterInterface::VISIBILITY_PUBLIC : AdapterInterface::VISIBILITY_PRIVATE;
+        $size = (int) $object['size'];
+
+        return compact('path', 'timestamp', 'type', 'visibility', 'size');
     }
 
     /**

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -391,4 +391,36 @@ class SftpTests extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('chdir')->with('/root/')->andReturn(false);
         $adapter->connect();
     }
+
+    /**
+     * @dataProvider adapterProvider
+     */
+    public function testListContentsDir($filesystem, $adapter, $mock)
+    {
+        $mock
+            ->shouldReceive('rawlist')
+            ->andReturn(
+                [
+                    'dirname' =>
+                        [
+                        'type'        => NET_SFTP_TYPE_DIRECTORY,
+                        'mtime'       => time(),
+                        'permissions' => 0777,
+                        'filename'    => 'dirname'
+                        ],
+                    'filename' =>
+                        [
+                        'type'        => 1,
+                        'mtime'       => time(),
+                        'size'        => 20,
+                        'permissions' => 0777,
+                        'filename'    => 'filename'
+                        ],
+                ]
+            );
+
+        $listing = $filesystem->listContents('');
+        $this->assertInternalType('array', $listing);
+        $this->assertCount(2, $listing);
+    }
 }


### PR DESCRIPTION
## What does this Pull Request Do?
- Modified the `normalizeListingObject()` method. Identify the type of the object to normalize. If it's a 'file' the method will still return the same as before, if it's a 'dir' we take out `visibility` and `size` from the returned array.
## How should this be manually tested?

A test was included with a similar output you can get in a server, which doesn't include the 'size'.

The test is mostly the same as `testListContents`. I can fix that test to reflect the situation where the server doesn't return the 'size' and remove the last test I created, if you think it's best.
## Any background context you want to provide?

Currently there's a php `Notice` when trying to list the content of a directory with sub-directories.
## What are the relevant tickets?
- [Undefined index: size when trying to get the listing of a directories with subdirectories · Issue #2 · thephpleague/flysystem-sftp](https://github.com/thephpleague/flysystem-sftp/issues/2)
## Any extra info?

This is a minor bug. Please, give it a try and let me know.
