### PR TITLE
Add setter and getter for directoryPerm parameter

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -71,6 +71,30 @@ class SftpAdapter extends AbstractFtpAdapter
     }
 
     /**
+     * Set permissions for new directory
+     *
+     * @param int $directoryPerm
+     *
+     * @return $this
+     */
+    public function setDirectoryPerm($directoryPerm)
+    {
+        $this->directoryPerm = $directoryPerm;
+
+        return $this;
+    }
+
+    /**
+     * Get permissions for new directory
+     *
+     * @return int
+     */
+    public function getDirectoryPerm()
+    {
+        return $this->directoryPerm;
+    }
+
+    /**
      * Inject the Net_SFTP instance.
      *
      * @param Net_SFTP $connection

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -272,7 +272,10 @@ class SftpTests extends PHPUnit_Framework_TestCase
      */
     public function testCreateDir($filesystem, $adapter, $mock)
     {
-        $mock->shouldReceive('mkdir')->andReturn(true, false);
+        $directoryPerm = 12345;
+        $adapter->setDirectoryPerm($directoryPerm);
+        $mock->shouldReceive('mkdir')->once()->with('dirname', $directoryPerm, true)->andReturn(true);
+        $mock->shouldReceive('mkdir')->once()->with('dirname_fails', $directoryPerm, true)->andReturn(false);
         $this->assertTrue($filesystem->createDir('dirname'));
         $this->assertFalse($filesystem->createDir('dirname_fails'));
     }
@@ -333,6 +336,16 @@ class SftpTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($adapter, $adapter->setPrivateKey($key));
         $this->assertInstanceOf('Crypt_RSA', $adapter->getPrivateKey());
         @unlink($key);
+    }
+
+    /**
+     * @dataProvider  adapterProvider
+     */
+    public function testDirectoryPermSetGet($filesystem, $adapter, $mock)
+    {
+        $directoryPerm = 12345;
+        $this->assertEquals($adapter, $adapter->setDirectoryPerm($directoryPerm));
+        $this->assertEquals($directoryPerm, $adapter->getDirectoryPerm());
     }
 
     /**


### PR DESCRIPTION
Add setter and getter for directoryPerm parameter. Related to https://github.com/helios-ag/FMElfinderBundle/pull/133 and https://github.com/thephpleague/flysystem/pull/457
