### PR TITLE
Implement readStream

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -315,6 +315,24 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * {@inheritdoc}
      */
+    public function readStream($path)
+    {
+        $stream = tmpfile();
+        $connection = $this->getConnection();
+
+        if ($connection->get($path, $stream) === false) {
+            fclose($stream);
+            return false;
+        }
+
+        rewind($stream);
+
+        return compact('stream');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function update($path, $contents, Config $config)
     {
         return $this->write($path, $contents, $config);

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -301,6 +301,22 @@ class SftpTests extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider  adapterProvider
      */
+    public function testReadStream($filesystem, $adapter, $mock)
+    {
+        $stream = tmpfile();
+        fwrite($stream, 'something');
+        $mock->shouldReceive('get')->andReturn($stream, false);
+        $result = $adapter->readStream('something');
+        $this->assertInternalType('array', $result);
+        $this->assertArrayHasKey('stream', $result);
+        $this->assertInternalType('resource', $result['stream']);
+        $this->assertFalse($adapter->readStream('something'));
+        fclose($stream);
+    }
+
+    /**
+     * @dataProvider  adapterProvider
+     */
     public function testGetMimetype($filesystem, $adapter, $mock)
     {
         $mock->shouldReceive('stat')->andReturn([


### PR DESCRIPTION
Even though `phpseclib` does support writing directly to a resource, `StreamedReadingTrait` polyfill was being used for `readStream`, which meant that entire file contents would be read into memory before being written to a stream. This would result in `Allowed memory size of x bytes exhausted` errors when attempting to download large files.

Tested this with a 1.7GB file and memory usage did not exceed 10MB.
