### PR TITLE
Fix path separator when connecting from Windows machine to Linux/Unix

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -205,7 +205,7 @@ class SftpAdapter extends AbstractFtpAdapter
                 continue;
             }
 
-            $path = empty($directory) ? $filename : ($directory.DIRECTORY_SEPARATOR.$filename);
+            $path = empty($directory) ? $filename : ($directory.'/'.$filename);
             $result[] = $this->normalizeListingObject($path, $object);
 
             if ($recursive && $object['type'] === NET_SFTP_TYPE_DIRECTORY) {


### PR DESCRIPTION
If a Windows machine connects to a Linux server, this adapter will attempt to use `\` as the path separator, which obviously won't work on Linux/Unix. 

I wasn't sure if there's a way to determine the correct server separator via phpseclib, so I defaulted to Linux/Unix style, since it should work on Windows as well.
