### PR TITLE
update phpseclib to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.4.0",
         "league/flysystem": "~1.0",
-        "phpseclib/phpseclib": "~0.3.8"
+        "phpseclib/phpseclib": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "andreybolonin/flysystem-sftp",
+    "name": "league/flysystem-sftp",
     "description": "Flysystem adapter for SFTP",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "league/flysystem-sftp",
+    "name": "andreybolonin/flysystem-sftp",
     "description": "Flysystem adapter for SFTP",
     "license": "MIT",
     "authors": [

--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -207,7 +207,7 @@ class SftpAdapter extends AbstractFtpAdapter
             $path = empty($directory) ? $filename : ($directory.'/'.$filename);
             $result[] = $this->normalizeListingObject($path, $object);
 
-            if ($recursive && $object['type'] === SFTP_TYPE_DIRECTORY) {
+            if ($recursive && $object['type'] === NET_SFTP_TYPE_DIRECTORY) {
                 $result = array_merge($result, $this->listDirectoryContents($path));
             }
         }

--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -11,6 +11,7 @@ use League\Flysystem\Config;
 use League\Flysystem\Util;
 use LogicException;
 use phpseclib\Net\SFTP;
+use phpseclib\Crypt\RSA;
 use RuntimeException;
 
 class SftpAdapter extends AbstractFtpAdapter
@@ -169,7 +170,7 @@ class SftpAdapter extends AbstractFtpAdapter
             $this->privatekey = file_get_contents($this->privatekey);
         }
 
-        $key = new Crypt_RSA();
+        $key = new RSA();
 
         if ($this->password) {
             $key->setPassword($this->password);

--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -10,7 +10,7 @@ use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
 use League\Flysystem\Util;
 use LogicException;
-use Net_SFTP;
+use phpseclib\Net\SFTP;
 use RuntimeException;
 
 class SftpAdapter extends AbstractFtpAdapter
@@ -93,13 +93,13 @@ class SftpAdapter extends AbstractFtpAdapter
     }
 
     /**
-     * Inject the Net_SFTP instance.
+     * Inject the SFTP instance.
      *
-     * @param Net_SFTP $connection
+     * @param SFTP $connection
      *
      * @return $this
      */
-    public function setNetSftpConnection(Net_SFTP $connection)
+    public function setNetSftpConnection(SFTP $connection)
     {
         $this->connection = $connection;
 
@@ -111,7 +111,7 @@ class SftpAdapter extends AbstractFtpAdapter
      */
     public function connect()
     {
-        $this->connection = $this->connection ?: new Net_SFTP($this->host, $this->port, $this->timeout);
+        $this->connection = $this->connection ?: new SFTP($this->host, $this->port, $this->timeout);
         $this->login();
         $this->setConnectionRoot();
     }
@@ -207,7 +207,7 @@ class SftpAdapter extends AbstractFtpAdapter
             $path = empty($directory) ? $filename : ($directory.'/'.$filename);
             $result[] = $this->normalizeListingObject($path, $object);
 
-            if ($recursive && $object['type'] === NET_SFTP_TYPE_DIRECTORY) {
+            if ($recursive && $object['type'] === SFTP_TYPE_DIRECTORY) {
                 $result = array_merge($result, $this->listDirectoryContents($path));
             }
         }
@@ -466,7 +466,7 @@ class SftpAdapter extends AbstractFtpAdapter
      */
     public function isConnected()
     {
-        if ($this->connection instanceof Net_SFTP && $this->connection->isConnected()) {
+        if ($this->connection instanceof SFTP && $this->connection->isConnected()) {
             return true;
         }
 

--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -2,7 +2,6 @@
 
 namespace League\Flysystem\Sftp;
 
-use Crypt_RSA;
 use InvalidArgumentException;
 use League\Flysystem\Adapter\AbstractFtpAdapter;
 use League\Flysystem\Adapter\Polyfill\StreamedCopyTrait;
@@ -148,7 +147,7 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * Get the password, either the private key or a plain text password.
      *
-     * @return Crypt_RSA|string
+     * @return RSA|string
      */
     public function getPassword()
     {
@@ -162,7 +161,7 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * Get the private get with the password or private key contents.
      *
-     * @return Crypt_RSA
+     * @return RSA
      */
     public function getPrivateKey()
     {
@@ -286,7 +285,7 @@ class SftpAdapter extends AbstractFtpAdapter
         $this->ensureDirectory(Util::dirname($path));
         $config = Util::ensureConfig($config);
 
-        if (! $connection->put($path, $contents, NET_SFTP_STRING)) {
+        if (! $connection->put($path, $contents, SFTP::SOURCE_STRING)) {
             return false;
         }
 

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -17,7 +17,7 @@ class SftpTests extends PHPUnit_Framework_TestCase
     public function adapterProvider()
     {
         $adapter = new Sftp(['username' => 'test', 'password' => 'test']);
-        $mock = Mockery::mock('Net_SFTP');
+        $mock = Mockery::mock('phpseclib\Net\SFTP');
         $mock->shouldReceive('__toString')->andReturn('Net_SFTP');
         $mock->shouldReceive('isConnected')->andReturn(true);
         $mock->shouldReceive('disconnect');
@@ -419,7 +419,7 @@ class SftpTests extends PHPUnit_Framework_TestCase
      */
     public function testIsNotConnected($filesystem, SftpAdapter $adapter)
     {
-        $mock = Mockery::mock('Net_SFTP');
+        $mock = Mockery::mock('phpseclib\Net\SFTP');
         $mock->shouldReceive('__toString')->andReturn('Net_SFTP');
         $mock->shouldReceive('disconnect');
         $mock->shouldReceive('isConnected')->andReturn(false);

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -342,7 +342,7 @@ class SftpTests extends PHPUnit_Framework_TestCase
     {
         $key = 'private.key';
         $this->assertEquals($adapter, $adapter->setPrivateKey($key));
-        $this->assertInstanceOf('Crypt_RSA', $adapter->getPrivateKey());
+        $this->assertInstanceOf('phpseclib\Crypt\RSA', $adapter->getPrivateKey());
     }
 
     /**
@@ -352,7 +352,7 @@ class SftpTests extends PHPUnit_Framework_TestCase
     {
         file_put_contents($key = __DIR__.'/some.key', 'key contents');
         $this->assertEquals($adapter, $adapter->setPrivateKey($key));
-        $this->assertInstanceOf('Crypt_RSA', $adapter->getPrivateKey());
+        $this->assertInstanceOf('phpseclib\Crypt\RSA', $adapter->getPrivateKey());
         @unlink($key);
     }
 
@@ -383,7 +383,7 @@ class SftpTests extends PHPUnit_Framework_TestCase
     {
         $key = 'private.key';
         $this->assertEquals($adapter, $adapter->setPrivateKey($key));
-        $this->assertInstanceOf('Crypt_RSA', $adapter->getPassword());
+        $this->assertInstanceOf('phpseclib\Crypt\RSA', $adapter->getPassword());
     }
 
     /**


### PR DESCRIPTION
``` sh
2015-09-22 13:38:14 [-][-][-][error][yii\base\ErrorException:2] exception 'yii\base\ErrorException' with message 'unpack(): Type N: not enough input, need 4, have 1' in /data/cporder-2-0/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php:2826
Stack trace:
#0 [internal function]: yii\base\ErrorHandler->handleError(2, 'unpack(): Type ...', '/data/cporder-2...', 2826, Array)
#1 /data/cporder-2-0/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(2826): unpack('Nlength', '\x00')
#2 /data/cporder-2-0/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(2771): Net_SSH2->_filter('P\x00\x00\x00\x17hostkeys-0...')
#3 /data/cporder-2-0/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(2974): Net_SSH2->_get_binary_packet()
#4 /data/cporder-2-0/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php(441): Net_SSH2->_get_channel_packet(256)
#5 /data/cporder-2-0/vendor/league/flysystem-sftp/src/SftpAdapter.php(126): Net_SFTP->login('CentralPoint', 'VoOe8TVK4QW5mB9...')
#6 /data/cporder-2-0/vendor/league/flysystem-sftp/src/SftpAdapter.php(115): League\Flysystem\Sftp\SftpAdapter->login()
#7 /data/cporder-2-0/vendor/league/flysystem/src/Adapter/AbstractFtpAdapter.php(563): League\Flysystem\Sftp\SftpAdapter->connect()
#8 /data/cporder-2-0/vendor/league/flysystem-sftp/src/SftpAdapter.php(194): League\Flysystem\Adapter\AbstractFtpAdapter->getConnection()
#9 /data/cporder-2-0/vendor/league/flysystem/src/Adapter/AbstractFtpAdapter.php(317): League\Flysystem\Sftp\SftpAdapter->listDirectoryContents('download', false)
#10 /data/cporder-2-0/vendor/league/flysystem/src/Filesystem.php(268): League\Flysystem\Adapter\AbstractFtpAdapter->listContents('download', false)
#11 /data/cporder-2-0/vendor/league/flysystem/src/Plugin/ListFiles.php(27): League\Flysystem\Filesystem->listContents('download', false)
#12 [internal function]: League\Flysystem\Plugin\ListFiles->handle('download')
#13 /data/cporder-2-0/vendor/league/flysystem/src/Plugin/PluggableTrait.php(67): call_user_func_array(Array, Array)
#14 /data/cporder-2-0/vendor/league/flysystem/src/Plugin/PluggableTrait.php(83): League\Flysystem\Filesystem->invokePlugin('listFiles', Array, Object(League\Flysystem\Filesystem))
#15 /data/cporder-2-0/components/Transports/TransportSFTP.php(71): League\Flysystem\Filesystem->__call('listFiles', Array)
#16 /data/cporder-2-0/components/Transports/TransportSFTP.php(71): League\Flysystem\Filesystem->listFiles('download')
#17 /data/cporder-2-0/commands/ServiceController.php(740): app\components\Transports\TransportSFTP->get()
#18 [internal function]: app\commands\ServiceController->actionTieGetOrd()
#19 /data/cporder-2-0/vendor/yiisoft/yii2/base/InlineAction.php(55): call_user_func_array(Array, Array)
#20 /data/cporder-2-0/vendor/yiisoft/yii2/base/Controller.php(151): yii\base\InlineAction->runWithParams(Array)
#21 /data/cporder-2-0/vendor/yiisoft/yii2/console/Controller.php(91): yii\base\Controller->runAction('tie-get-ord', Array)
#22 /data/cporder-2-0/vendor/yiisoft/yii2/base/Module.php(455): yii\console\Controller->runAction('tie-get-ord', Array)
#23 /data/cporder-2-0/vendor/yiisoft/yii2/console/Application.php(167): yii\base\Module->runAction('service/tie-get...', Array)
#24 /data/cporder-2-0/vendor/yiisoft/yii2/console/Application.php(143): yii\console\Application->runAction('service/tie-get...', Array)
#25 /data/cporder-2-0/vendor/yiisoft/yii2/base/Application.php(375): yii\console\Application->handleRequest(Object(yii\console\Request))
#26 /data/cporder-2-0/yii(15): yii\base\Application->run()
#27 {main}
```

https://github.com/phpseclib/phpseclib/issues/669 fixed in 2.x.x version.
