### PR TITLE
Store absolute path for further reference.

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -142,6 +142,7 @@ class SftpAdapter extends AbstractFtpAdapter
         if (! $this->connection->chdir($root)) {
             throw new RuntimeException('Root is invalid or does not exist: '.$root);
         }
+        $this->root = $this->connection->pwd;
     }
 
     /**


### PR DESCRIPTION
This is needed when creating directories and initial root was a relative path, else the root would be relative to the chdir'd path.
