### PR TITLE
Speedup build and reduced package size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+changelog.md export-ignore
+composer.lock export-ignore
+phpunit.hhvm.xml export-ignore
+phpunit.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,36 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+env:
+  matrix:
+    - PREFER_LOWEST="--prefer-lowest"
+    - PREFER_LOWEST=""
+
 php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
+before_install:
+  - composer self-up
+  - composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
+
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - composer update --no-interaction --prefer-stable $PREFER_LOWEST
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --verbose
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi;'
 
 matrix:
-    allow_failures:
-        - php: hhvm
-    fast_finish: true
+  fast_finish: true

--- a/phpunit.hhvm.xml
+++ b/phpunit.hhvm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="./phpunit.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/phpunit.php
+++ b/phpunit.php
@@ -1,3 +1,0 @@
-<?php
-
-include __DIR__.'/vendor/autoload.php';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="./phpunit.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"


### PR DESCRIPTION
Hello,

I've made some small improvements:
- Reduce package size by 60%
- Speed up TravisCI builds with Container environment and caching
- Test also with lowest possible dependencies
- Run builds on PHP 7 and made HHVM a first-class citizen
- Removed not needed `phpunit.php`

If you add a **secret** environment variable named `GITHUB_OAUTH_TOKEN` to the Travis job you won't run into „api rate limit“ errors.
