### PR TITLE
Set password and private key to null after authenticating

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -160,6 +160,13 @@ class SftpAdapter extends AbstractFtpAdapter
     {
         $authentication = $this->getAuthentication();
 
+        /*
+         * We no longer need the password or private key. Remove them so that they cannot accidentally be exposed after
+         * login (e.g. when a stacktrace or scope is dumped).
+         */
+        $this->password   = null;
+        $this->privatekey = null;
+
         if (! $this->connection->login($this->username, $authentication)) {
             throw new LogicException('Could not login with username: '.$this->username.', host: '.$this->host);
         }
@@ -191,7 +198,7 @@ class SftpAdapter extends AbstractFtpAdapter
      *
      * @return Agent|RSA|string
      */
-    public function getAuthentication()
+    protected function getAuthentication()
     {
         if ($this->useAgent) {
             return $this->getAgent();
@@ -207,7 +214,10 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * Get the password, a plain text password.
      *
-     * @return string
+     * After login, this method may return null.
+     *
+     * @deprecated
+     * @return string|null
      */
     public function getPassword()
     {
@@ -219,7 +229,7 @@ class SftpAdapter extends AbstractFtpAdapter
      *
      * @return RSA
      */
-    public function getPrivateKey()
+    protected function getPrivateKey()
     {
         if (@is_file($this->privatekey)) {
             $this->privatekey = file_get_contents($this->privatekey);


### PR DESCRIPTION
The password and / or private key may be highly sensitive and should not be kept in memory. It is possible that error handlers or other tools might log or access this.

There should not be any public methods to retrieve this information from the object. 

Note that this changes the public API of the class and thus should warrant a new major version. 

I removed some tests that accessed these private methods. If you're really fond of these tests, let me know and I will create new ones to replace them. 
