### PR TITLE
added URL setter and getter

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -46,7 +46,7 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * @var array
      */
-    protected $configurable = ['host', 'hostFingerprint', 'port', 'username', 'password', 'useAgent', 'agent', 'timeout', 'root', 'privateKey', 'permPrivate', 'permPublic', 'directoryPerm', 'NetSftpConnection'];
+    protected $configurable = ['host', 'hostFingerprint', 'port', 'username', 'password', 'useAgent', 'agent', 'timeout', 'root', 'privateKey', 'permPrivate', 'permPublic', 'directoryPerm', 'NetSftpConnection', 'url'];
 
     /**
      * @var array
@@ -161,6 +161,36 @@ class SftpAdapter extends AbstractFtpAdapter
         $this->connection = $connection;
 
         return $this;
+    }
+
+    /**
+     * Set the url.
+     *
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * get full url from path if url is set.
+     *
+     * @param string path
+     *
+     * @return string
+     */
+    public function getUrl($path)
+    {
+        if (!empty($this->url)) {
+            return rtrim($this->url,'/').'/'.ltrim($path, '/');
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
One might want to have access to a full public url for a file if it is available (i.e. sftp files to another server to be referenced publicly).  Also, when using this package with Laravel, most other adapters have a getUrl() method to allow the user to fetch a public url to the files if available.