### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpseclib/phpseclib": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.8.35",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -5,11 +5,12 @@ use League\Flysystem\FilesystemInterface;
 use League\Flysystem\Sftp\SftpAdapter as Sftp;
 use League\Flysystem\Sftp\SftpAdapter;
 use phpseclib\System\SSH\Agent;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \League\Flysystem\Sftp\SftpAdapter<extended>
  */
-class SftpTests extends PHPUnit_Framework_TestCase
+class SftpTests extends TestCase
 {
     protected function setup()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.