### PR TITLE
Use 'load' instead of 'loadKey'

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -268,7 +268,7 @@ class SftpAdapter extends AbstractFtpAdapter
             $key->setPassword($password);
         }
 
-        $key->loadKey($this->privatekey);
+        $key->load($this->privatekey);
 
         return $key;
     }


### PR DESCRIPTION
The 'loadKey' method was renamed in the following commit: https://github.com/phpseclib/phpseclib/commit/ec3fe7277b8b1c4250c939f39783840ca12c1a19?diff=unified

Haven't ran into issues so far, but the latests `composer update` run we ran into this. Perhaps an constraint or new release was created upstream.