### PR TITLE
Added dual authentication support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ $adapter = new SftpAdapter([
     'username' => 'username',
     'password' => 'password',
     'privateKey' => 'path/to/or/contents/of/privatekey',
+    'passphrase' => 'passphrase-for-privateKey',
     'root' => '/path/to/root',
     'timeout' => 10,
     'directoryPerm' => 0755

--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -51,7 +51,7 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * @var array
      */
-    protected $configurable = ['host', 'hostFingerprint', 'port', 'username', 'password', 'useAgent', 'agent', 'timeout', 'root', 'privateKey', 'permPrivate', 'permPublic', 'directoryPerm', 'NetSftpConnection'];
+    protected $configurable = ['host', 'hostFingerprint', 'port', 'username', 'password', 'useAgent', 'agent', 'timeout', 'root', 'privateKey', 'passphrase', 'permPrivate', 'permPublic', 'directoryPerm', 'NetSftpConnection'];
 
     /**
      * @var array
@@ -62,6 +62,11 @@ class SftpAdapter extends AbstractFtpAdapter
      * @var int
      */
     protected $directoryPerm = 0744;
+
+    /**
+     * @var string
+     */
+    private $passphrase;
 
     /**
      * Prefix a path.
@@ -102,6 +107,20 @@ class SftpAdapter extends AbstractFtpAdapter
     public function setPrivateKey($key)
     {
         $this->privatekey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the passphrase for the privatekey.
+     *
+     * @param string $passphrase
+     *
+     * @return $this
+     */
+    public function setPassphrase($passphrase)
+    {
+        $this->passphrase = $passphrase;
 
         return $this;
     }
@@ -196,8 +215,14 @@ class SftpAdapter extends AbstractFtpAdapter
 
         $authentication = $this->getAuthentication();
 
+
         if (! $this->connection->login($this->getUsername(), $authentication)) {
-            throw new LogicException('Could not login with username: '.$this->getUsername().', host: '.$this->host);
+
+            //try double authentication, key is already given so now give password
+            if (!$authentication instanceof RSA
+                || ! $this->connection->login($this->getUsername(), $this->getPassword())) {
+                throw new LogicException('Could not login with username: '.$this->getUsername().', host: '.$this->host);
+            }
         }
 
         if ($authentication instanceof Agent) {
@@ -265,13 +290,25 @@ class SftpAdapter extends AbstractFtpAdapter
 
         $key = new RSA();
 
-        if ($password = $this->getPassword()) {
+        if ($password = $this->getPassphrase()) {
             $key->setPassword($password);
         }
 
         $key->loadKey($this->privatekey);
 
         return $key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassphrase()
+    {
+        if ($this->passphrase === null) {
+            //Added for backward compatibility
+            return $this->getPassword();
+        }
+        return $this->passphrase;
     }
 
     /**

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -432,6 +432,58 @@ class SftpTests extends TestCase
         $this->assertInstanceOf('phpseclib\Crypt\RSA', $adapter->getAuthentication());
     }
 
+
+    /**
+     * @dataProvider  adapterProvider
+     */
+    public function testPassphraseSetGet($filesystem, SftpAdapter $adapter, $mock)
+    {
+        $passphrase = 'passphrase';
+        $this->assertEquals($adapter, $adapter->setPassphrase($passphrase));
+        $this->assertEquals($passphrase, $adapter->getPassphrase());
+    }
+
+
+    /**
+     * @dataProvider  adapterProvider
+     */
+    public function testPassphraseFallback($filesystem, SftpAdapter $adapter, $mock)
+    {
+        $passphrase = 'passphrase';
+        $this->assertEquals($adapter, $adapter->setPassword($passphrase));
+        $this->assertEquals($passphrase, $adapter->getPassphrase());
+    }
+
+    /**
+     * @dataProvider  adapterProvider
+     */
+    public function testPassphraseAndPasswordFallback($filesystem, SftpAdapter $adapter, $mock)
+    {
+        $passphrase = 'passphrase';
+        $password = 'password';
+        $this->assertEquals($adapter, $adapter->setPassword($password));
+        $this->assertEquals($adapter, $adapter->setPassphrase($passphrase));
+        $this->assertEquals($passphrase, $adapter->getPassphrase());
+        $this->assertEquals($password, $adapter->getPassword());
+    }
+
+
+    /**
+     * @dataProvider  adapterProvider
+     */
+    public function testConnectWithDoubleAuthentication($filesystem, $adapter, $mock)
+    {
+        $adapter->setPrivateKey('private.key');
+        $adapter->setNetSftpConnection($mock);
+
+        $expectedAuths = [$adapter->getPrivateKey(), 'test'];
+        $mock->shouldReceive('login')->with('test', Mockery::on(function($auth) use (&$expectedAuths) {
+            return $auth == array_shift($expectedAuths);
+        }))->twice()->andReturn(false, true);
+
+        $adapter->connect();
+    }
+
     /**
      * @dataProvider  adapterProvider
      * @expectedException LogicException


### PR DESCRIPTION
This would fix #25 

It offers a way to add double authentication while maintaining backwards compatibility. 
Although this problem is also fixed by the ability to inject a connection, this seems easier to implement.