### PR TITLE
Throw an Exception if can't connect to check Host Fingerprint

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -187,7 +187,13 @@ class SftpAdapter extends AbstractFtpAdapter
     protected function login()
     {
         if ($this->hostFingerprint) {
-            $actualFingerprint = $this->getHexFingerprintFromSshPublicKey($this->connection->getServerPublicHostKey());
+            $publicKey = $this->connection->getServerPublicHostKey();
+
+            if ($publicKey === false) {
+                throw new LogicException('Could not connect to server to verify public key.');
+            }
+
+            $actualFingerprint = $this->getHexFingerprintFromSshPublicKey($publicKey);
 
             if (0 !== strcasecmp($this->hostFingerprint, $actualFingerprint)) {
                 throw new LogicException('The authenticity of host '.$this->host.' can\'t be established.');

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -616,4 +616,32 @@ class SftpTests extends TestCase
 
         $adapter->connect();
     }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Could not connect to server to verify public key.
+     */
+    public function testCantConnectToCheckHostFingerprintAbortsLogin()
+    {
+        $adapter = new SftpAdapter([
+            'host' => 'example.org',
+            'username' => 'user',
+            'password' => '123456',
+            'hostFingerprint' => '00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00',
+        ]);
+
+        $connection = Mockery::mock('phpseclib\Net\SFTP');
+
+        $connection->shouldReceive('getServerPublicHostKey')
+            ->andReturn(false);
+
+        $connection->shouldReceive('login')
+            ->never();
+
+        $connection->shouldReceive('disconnect');
+
+        $adapter->setNetSftpConnection($connection);
+
+        $adapter->connect();
+    }
 }

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -633,11 +633,12 @@ class SftpTests extends TestCase
         $connection = Mockery::mock('phpseclib\Net\SFTP');
 
         $connection->shouldReceive('getServerPublicHostKey')
-            ->andReturn(false);
+            ->andReturn(false); // getServerPublicHostKey returns false if it cant connect.
 
         $connection->shouldReceive('login')
             ->never();
 
+        $connection->shouldReceive('disableStatCache');
         $connection->shouldReceive('disconnect');
 
         $adapter->setNetSftpConnection($connection);


### PR DESCRIPTION
If this adapter can't connect to the server it still assumes it has the public key and tries to verify it causing the following error: `ErrorException (Undefined offset: 1) flysystem-sftp/src/SftpAdapter.php:217`

This change provides a more useful error