### PR TITLE
Fix invalid visibility

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -503,7 +503,7 @@ class SftpAdapter extends AbstractFtpAdapter
 
         $result = Util::map($info, $this->statMap);
         $result['type'] = $info['type'] === NET_SFTP_TYPE_DIRECTORY ? 'dir' : 'file';
-        $result['visibility'] = $info['permissions'] & $this->permPublic ? 'public' : 'private';
+        $result['visibility'] = $info['permissions'] & (0777 ^ $this->permPrivate) ? 'public' : 'private';
 
         return $result;
     }

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -275,6 +275,24 @@ class SftpTests extends TestCase
     /**
      * @dataProvider  adapterProvider
      */
+    public function testGetVisibilityPrivate($filesystem, $adapter, $mock)
+    {
+        $mock->shouldReceive('stat')->andReturn([
+            'type'        => NET_SFTP_TYPE_DIRECTORY,
+            'mtime'       => time(),
+            'size'        => 20,
+            'permissions' => 0700,
+        ]);
+        $result = $adapter->getVisibility(uniqid().'object.ext');
+        $this->assertInternalType('array', $result);
+        $result = $result['visibility'];
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('private', $result);
+    }
+
+    /**
+     * @dataProvider  adapterProvider
+     */
     public function testGetTimestamp($filesystem, $adapter, $mock)
     {
         $mock->shouldReceive('stat')->andReturn([


### PR DESCRIPTION
getVisibility() always gets `public`. If set visibility as private and call getVisibility(), this return `public` value.

I added test to check this https://github.com/et-nik/flysystem-sftp/commit/272492da6ba540e3768355c33626f9150359ff62

After that tests has failed:
https://travis-ci.com/et-nik/flysystem-sftp/jobs/157303997#L566

I fixed visibility checking and added tests.