### PR TITLE
Bugfix: Directories or files named '0' do not show up in listContents

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -312,6 +312,8 @@ class SftpAdapter extends AbstractFtpAdapter
         }
 
         foreach ($listing as $filename => $object) {
+            // When directory entries have a numeric filename they are changed to int
+            $filename = (string) $filename;
             if (in_array($filename, ['.', '..'])) {
                 continue;
             }

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -657,4 +657,28 @@ class SftpTests extends TestCase
 
         $adapter->connect();
     }
+
+    /**
+     * @dataProvider adapterProvider
+     */
+    public function testListContentsWithZeroNamedDir($filesystem, $adapter, $mock)
+    {
+        $mock
+            ->shouldReceive('rawlist')
+            ->andReturn(
+                [
+                    '0' =>
+                        [
+                            'type'        => NET_SFTP_TYPE_DIRECTORY,
+                            'mtime'       => time(),
+                            'permissions' => 0777,
+                            'filename'    => '0'
+                        ]
+                ]
+            );
+
+        $listing = $filesystem->listContents('');
+        $this->assertInternalType('array', $listing);
+        $this->assertCount(1, $listing);
+    }
 }


### PR DESCRIPTION
When the filenames come from the phpseclib\Net\SFTP client they are passed
as array keys. If that filename is just '0' php handles it as an int.
In ContentListingFormatter there is a special case that handles !== '0',
since filename is an int in this case it does not match and is considered empty.

Just making sure filename is always a string solves this.