### PR TITLE
Refactoring exceptions

### DIFF
--- a/src/ConnectionErrorException.php
+++ b/src/ConnectionErrorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem\Sftp;
+
+class ConnectionErrorException extends \LogicException implements SftpAdapterException
+{
+}

--- a/src/InvalidRootException.php
+++ b/src/InvalidRootException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem\Sftp;
+
+class InvalidRootException extends \RuntimeException implements SftpAdapterException
+{
+}

--- a/src/SftpAdapterException.php
+++ b/src/SftpAdapterException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem\Sftp;
+
+interface SftpAdapterException
+{
+}


### PR DESCRIPTION
The change will allow you to better capture particular exceptions and  catch all the exceptions by iterface `SftpAdapterException` (the main thing I needed).

This is not a BC break, as the new expetion inherits from the original. As evidenced by successful tests, see https://github.com/thephpleague/flysystem-sftp/blob/master/tests/SftpAdapterTests.php#L604 and https://github.com/thephpleague/flysystem-sftp/blob/master/tests/SftpAdapterTests.php#L503 