### PR TITLE
fix(adapter): add separator to connection root only when necessary

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -267,22 +267,7 @@ class SftpAdapter extends AbstractFtpAdapter
             throw new InvalidRootException('Root is invalid or does not exist: '.$root);
         }
 
-        $this->root = $this->addSeparator(
-            $this->connection->pwd(),
-            $this->separator
-        );
-    }
-
-    /**
-     * Cap a value with separator where needed.
-     *
-     * @param string $value
-     * @param string $separator
-     * @return string
-     */
-    protected function addSeparator($value, $separator)
-    {
-        return substr($value, -1) === $separator ? $value : $value.$separator;
+        $this->setRoot($this->connection->pwd());
     }
 
     /**

--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -266,7 +266,23 @@ class SftpAdapter extends AbstractFtpAdapter
         if (! $this->connection->chdir($root)) {
             throw new InvalidRootException('Root is invalid or does not exist: '.$root);
         }
-        $this->root = $this->connection->pwd() . $this->separator;
+
+        $this->root = $this->addSeparator(
+            $this->connection->pwd(),
+            $this->separator
+        );
+    }
+
+    /**
+     * Cap a value with separator where needed.
+     *
+     * @param string $value
+     * @param string $separator
+     * @return string
+     */
+    protected function addSeparator($value, $separator)
+    {
+        return substr($value, -1) === $separator ? $value : $value.$separator;
     }
 
     /**


### PR DESCRIPTION
Fixes #92.

This should prevent setting something like `//folder` as the path. Please, test for any regressions you might think of.