### PR TITLE
Create root directory if it does not exist

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -263,6 +263,10 @@ class SftpAdapter extends AbstractFtpAdapter
             return;
         }
 
+        if (! $this->connection->is_dir($root) && ! $this->connection->mkdir($root)) {
+            throw new \RuntimeException('Root does not exist and could not be created: ' . $root . "\n" . "sftp errors:" . implode(",", $this->connection->getSFTPErrors()));
+        }
+
         if (! $this->connection->chdir($root)) {
             throw new InvalidRootException('Root is invalid or does not exist: '.$root);
         }

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -545,9 +545,39 @@ class SftpTests extends TestCase
         $adapter->setRoot('/root');
         $adapter->setNetSftpConnection($mock);
         $mock->shouldReceive('login')->with('test', 'test')->andReturn(true);
+        $mock->shouldReceive('is_dir')->with('/root/')->andReturn(true);
         $mock->shouldReceive('chdir')->with('/root/')->andReturn(true);
         $adapter->connect();
         $adapter->disconnect();
+    }
+
+    /**
+     * @dataProvider  adapterProvider
+     */
+    public function testConnectWithNotExistedRoot($filesystem, $adapter, $mock)
+    {
+        $adapter->setRoot('/root');
+        $adapter->setNetSftpConnection($mock);
+        $mock->shouldReceive('login')->with('test', 'test')->andReturn(true);
+        $mock->shouldReceive('is_dir')->with('/root/')->andReturn(false);
+        $mock->shouldReceive('mkdir')->with('/root/')->andReturn(true);
+        $mock->shouldReceive('chdir')->with('/root/')->andReturn(true);
+        $adapter->connect();
+        $adapter->disconnect();
+    }
+
+    /**
+     * @dataProvider  adapterProvider
+     * @expectedException RuntimeException
+     */
+    public function testConnectWithNotExistedRootAndCouldNotBeCreated($filesystem, $adapter, $mock)
+    {
+        $adapter->setRoot('/root');
+        $adapter->setNetSftpConnection($mock);
+        $mock->shouldReceive('login')->with('test', 'test')->andReturn(true);
+        $mock->shouldReceive('is_dir')->with('/root/')->andReturn(false);
+        $mock->shouldReceive('mkdir')->with('/root/')->andReturn(false);
+        $adapter->connect();
     }
 
     /**
@@ -559,6 +589,7 @@ class SftpTests extends TestCase
         $adapter->setRoot('/root');
         $adapter->setNetSftpConnection($mock);
         $mock->shouldReceive('login')->with('test', 'test')->andReturn(true);
+        $mock->shouldReceive('is_dir')->with('/root/')->andReturn(true);
         $mock->shouldReceive('chdir')->with('/root/')->andReturn(false);
         $adapter->connect();
     }


### PR DESCRIPTION
If I specify the root directory and it has not yet been created, create it after connect.