### PR TITLE
Handle listing objects without 'mtime' attribute in listContents()

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -384,7 +384,7 @@ class SftpAdapter extends AbstractFtpAdapter
         $permissions = $this->normalizePermissions($object['permissions']);
         $type = isset($object['type']) && ($object['type'] === 2) ?  'dir' : 'file';
 
-        $timestamp = $object['mtime'];
+        $timestamp = (isset($object['mtime'])) ? $object['mtime'] : null;
 
         if ($type === 'dir') {
             return compact('path', 'timestamp', 'type');

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -733,4 +733,21 @@ class SftpTests extends TestCase
         $this->assertInternalType('array', $listing);
         $this->assertCount(1, $listing);
     }
+
+    /**
+     * @dataProvider adapterProvider
+     */
+    public function testListContentsWithoutMTime($filesystem, $adapter, $mock)
+    {
+        $mock->shouldReceive('rawlist')->andReturn([
+            'dirname' => [
+                'type'        => NET_SFTP_TYPE_DIRECTORY,
+                'size'        => 20,
+                'permissions' => 0777,
+            ],
+        ]);
+        $listing = $adapter->listContents('');
+        $this->assertInternalType('array', $listing);
+        $this->assertCount(1, $listing);
+    }
 }


### PR DESCRIPTION
Currently SftpAdapter throws an `undefined index 'mtime'` error if the SFTP server returns no `mtime` attributes with the listing response. This fixes that by normalising this case to `null`.