### PR TITLE
Fix bogus directoryPerm 744 (Use 700 instead)

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -59,7 +59,7 @@ class SftpAdapter extends AbstractFtpAdapter
     /**
      * @var int
      */
-    protected $directoryPerm = 0744;
+    protected $directoryPerm = 0700;
 
     /**
      * @var string


### PR DESCRIPTION
The `0744` directory permission is insane:

```
[root@d0b3bff7d8f0 test1]# mkdir test1
[root@d0b3bff7d8f0 test1]# chmod 744 test1
[root@d0b3bff7d8f0 test1]# ls -ld test1
drwxr--r-- 2 root root 4096 Nov 20 10:32 test1
[root@d0b3bff7d8f0 test1]#
```

it should be either `755` (all enter and readdir) or `711` (all enter, but no readdir), or `700` (nobody enter but owner), because read permission on a directory without execute bit is totally useless, you can't read directory if you can't enter it and to enter you need the execute bit.

for the change to be backward compatible, I decided to go with `700`, but I really think the "public" was the intention here, i.e should be changed to `755` in 2.x