### PR TITLE
Call ensureParentDirectoryExists() with valid parameter when moving file

### DIFF
--- a/SftpAdapter.php
+++ b/SftpAdapter.php
@@ -308,7 +308,7 @@ class SftpAdapter implements FilesystemAdapter
         $connection = $this->connectionProvider->provideConnection();
 
         try {
-            $this->ensureParentDirectoryExists($destinationLocation, $config);
+            $this->ensureParentDirectoryExists($destination, $config);
         } catch (Throwable $exception) {
             throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
         }


### PR DESCRIPTION
The method `ensureParentDirectoryExists()` expects an unprefixed path.

Fixes: #118